### PR TITLE
docs: add pytest troubleshooting steps to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A Model Context Protocol (MCP) tool for interacting with Invertir Online (IOL) A
 
 - Claude Desktop App for Mac
 - Python 3.8+
+- Pytest + pytest-cov (plugin)
 - IOL trading account
 - Environment variables setup with your IOL credentials
 
@@ -101,6 +102,27 @@ pytest tests/test_client.py --cov=client -v
    - Verify your .env file exists and has correct credentials
    - Check IOL API status
    - Ensure your IOL account is active
+   
+3. If running tests fails with `ModuleNotFoundError: No module named 'httpx'`:
+   - Make sure you're inside the virtual environment:
+     ```bash
+     uv venv
+     source .venv/bin/activate
+     ```
+   - Be sure to run:
+     ```bash
+     uv sync
+     ```
+     
+4. If `pytest` shows `unrecognized arguments: --cov=client`:
+   - Install the `pytest-cov` plugin:
+     ```bash
+     uv pip install pytest-cov
+     ```
+   - Then re-run the tests:
+     ```bash
+     pytest --cov=client
+     ```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -109,10 +109,6 @@ pytest tests/test_client.py --cov=client -v
      uv venv
      source .venv/bin/activate
      ```
-   - Be sure to run:
-     ```bash
-     uv sync
-     ```
      
 4. If `pytest` shows `unrecognized arguments: --cov=client`:
    - Install the `pytest-cov` plugin:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.10"
 dependencies = [
     "cachetools>=5.5.2",
     "httpx>=0.28.1",
- "mcp[cli]>=1.3.0",
+    "mcp[cli]>=1.3.0",
 ]
 
 [tool.pytest.ini_options]
@@ -16,4 +16,5 @@ pythonpath = ["."]
 [dependency-groups]
 dev = [
     "pytest>=8.3.4",
+    "pytest-cov>=6.2.1"
 ]


### PR DESCRIPTION
This PR adds a troubleshooting section to the README.md, documenting common issues encountered when running tests with pytest in a fresh environment with no dependencies or virtual environment set up.

Specifically, it covers:

ModuleNotFoundError due to missing httpx

unrecognized arguments: --cov=client error due to missing pytest-cov

The need to create and activate the virtual environment using uv venv and source .venv/bin/activate

These steps are based on the experience of setting up the project from scratch in a clean environment.
